### PR TITLE
GitHub Actions workflow for building and pushing Docker image to Docker Hub

### DIFF
--- a/.github/workflows/push-dockerhub-go-docker-gha.yml
+++ b/.github/workflows/push-dockerhub-go-docker-gha.yml
@@ -1,0 +1,33 @@
+name: Build and push to Docker Hub
+
+on:
+  push:
+    paths:
+      - 'labs/go-docker-gha/**'
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./labs/go-docker-gha
+          push: true
+          tags: p2well/go-docker-gha:latest
+    


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the building and pushing of Docker images to Docker Hub whenever changes are pushed to the `main` branch within the `labs/go-docker-gha` directory.

Automation for Docker image management:

* [`.github/workflows/push-dockerhub-go-docker-gha.yml`](diffhunk://#diff-0a76ad313b9052087cd2c6694ad1bdee0a2ecdb0d3e10830f3ce130ace879888R1-R33): Introduced a new workflow named "Build and push to Docker Hub" to build and push Docker images using Docker Buildx. The workflow triggers on pushes to the `main` branch and includes steps for repository checkout, Docker Buildx setup, Docker Hub login using secrets, and building/pushing the Docker image with the tag `p2well/go-docker-gha:latest`.